### PR TITLE
Fix meta data parsing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/dmap"]
 	path = lib/dmap
 	url = https://github.com/dapphub/dmap.git
+[submodule "lib/jams"]
+	path = lib/jams
+	url = git@github.com:nmushegian/jams.git

--- a/config.jams
+++ b/config.jams
@@ -1,0 +1,4 @@
+{
+    eth_rpc https://mainnet.infura.io/v3/c0a739d64257448f855847c6e3d173e1
+    finality 60
+}

--- a/index.js
+++ b/index.js
@@ -1,18 +1,20 @@
 import { Command } from 'commander'
 import  lib  from './lib/dmap/dmap.js'
-import  { rpc }   from './rpc.js'
+import { rpc }  from './rpc.js'
 import { jams } from './lib/jams/jams.js'
 import { readFileSync } from 'fs'
+import os from  'os'
 const program = new Command();
-
-// TODO: DMFXYZ Should move this to a config provider that defaults to home directory
-// and allows optional flag for custom config path
-const config = jams(readFileSync("./config.jams", {encoding: 'utf-8'}))
+let config = {}
 
 program
     .name('dmap')
     .description('dmap interface tools')
-    .version('0.1.0');
+    .version('0.1.0')
+    .option('-c, --config-file <string>', 'path to your jams config file', `${os.homedir()}/.locktopus/config.jams`)
+    .hook('preAction', (_, __) => {
+        config = jams(readFileSync(program.opts().configFile, {encoding: 'utf-8'}))
+    });
 
 program.command('walk')
     .description('Read a value from a dpath with caching')

--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ const look = async (path) => {
     if (!hit) {
         const dmap = await rpc.getFacade(config.eth_rpc);
         const trace = await lib.walk2(dmap, path);
-        [meta, data] = trace.slice(-1)
+        const slice = trace.slice(-1)[0];
+        meta = slice['0']
+        data = slice['1']
         save(trace)
     }
     console.log(meta, data)

--- a/index.js
+++ b/index.js
@@ -1,8 +1,13 @@
-const { Command } = require('commander');
-const lib = require('./lib/dmap/dmap.js')
-const rpc = require('./rpc.js')
+import { Command } from 'commander'
+import  lib  from './lib/dmap/dmap.js'
+import  { rpc }   from './rpc.js'
+import { jams } from './lib/jams/jams.js'
+import { readFileSync } from 'fs'
 const program = new Command();
-const config_URL_todo = 'https://mainnet.infura.io/v3/c0a739d64257448f855847c6e3d173e1'
+
+// TODO: DMFXYZ Should move this to a config provider that defaults to home directory
+// and allows optional flag for custom config path
+const config = jams(readFileSync("./config.jams", {encoding: 'utf-8'}))
 
 program
     .name('dmap')
@@ -29,7 +34,7 @@ const save = (trace) => {
 const look = async (path) => {
     let [hit, meta, data] = seek(path)
     if (!hit) {
-        const dmap = await rpc.getFacade(config_URL_todo);
+        const dmap = await rpc.getFacade(config.eth_rpc);
         const trace = await lib.walk2(dmap, path);
         [meta, data] = trace.slice(-1)
         save(trace)

--- a/index.js
+++ b/index.js
@@ -38,9 +38,7 @@ const look = async (path) => {
     if (!hit) {
         const dmap = await rpc.getFacade(config.eth_rpc);
         const trace = await lib.walk2(dmap, path);
-        const slice = trace.slice(-1)[0];
-        meta = slice['0']
-        data = slice['1']
+        [meta, data] = Object.values(trace.slice(-1)[0]);
         save(trace)
     }
     console.log(meta, data)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "locktopus",
   "version": "0.1.0",
+  "type": "module",
   "scripts": {
     "initialize": "npm i && npm run download-submodules && npm run install-submodules",
     "download-submodules": "git submodule update --init --recursive --remote",
@@ -11,6 +12,7 @@
   },
   "dependencies": {
     "commander": "^9.3.0",
+    "jams.js": "^0.0.7",
     "node-fetch": "^3.2.4"
   }
 }

--- a/rpc.js
+++ b/rpc.js
@@ -1,7 +1,7 @@
 const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
-const lib = require("./lib/dmap/dmap")
+import lib from "./lib/dmap/dmap.js"
 
-module.exports = rpc = {}
+export let rpc = {}
 
 rpc.makeRPC = async (url, method, params) => {
     let result = null


### PR DESCRIPTION
Before, the entirety of the last entry from `walk2` was being assigned to `meta` because it was an object not an array. This PR makes an attempt to correctly parse the individual values from the last object in the trace. Note this builds off of #3 WIP. 